### PR TITLE
#1028 Fix member of, media of prepopulate via URL query

### DIFF
--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -115,7 +115,7 @@ class ManageMembersController extends EntityController {
           $bundle->label(),
           $entity_add_form,
           [$bundle_type => $bundle->id()],
-          ['query' => ["edit[$field]" => $node->id()]]
+          ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
         ),
       ];
     }


### PR DESCRIPTION
**GitHub Issue**: (link)

https://github.com/Islandora-CLAW/CLAW/issues/1028

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Fix path passed in URL query that Prepopulate module uses to inject parent Repository Item into node or media entity form, e.g. from `?edit%5Bfield_member_of%5D=1` to `?edit%5Bfield_member_of%5D%5Bwidget%5D%5B0%5D%5Btarget_id%5D=1`

A brief description of what the intended result of the PR will be and/or what
 problem it solves.

Per #1028, add repository item, click members tab, add member, confirm that Member of field is correctly populated.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers